### PR TITLE
add id command

### DIFF
--- a/gochain.go
+++ b/gochain.go
@@ -55,6 +55,41 @@ func (rpc *RPCClient) GetSnapshot(ctx context.Context) (*clique.Snapshot, error)
 	return rpc.client.SnapshotAt(ctx, nil)
 }
 
+type ID struct {
+	NetworkID   *big.Int    `json:"network_id"`
+	ChainID     *big.Int    `json:"chain_id"`
+	GenesisHash common.Hash `json:"genesis_hash"`
+}
+
+func (rpc *RPCClient) GetID(ctx context.Context) (*ID, error) {
+	var id ID
+	netID, err := rpc.client.NetworkID(ctx)
+	if err != nil {
+		log.Println("Failed to get network ID:", err)
+		netID = nil
+	}
+	if netID != nil {
+		id.NetworkID = netID
+	}
+	chainID, err := rpc.client.ChainID(ctx)
+	if err != nil {
+		log.Println("Failed to get chain ID:", err)
+		chainID = nil
+	}
+	if chainID != nil {
+		id.ChainID = chainID
+	}
+	gen, err := rpc.client.BlockByNumber(ctx, big.NewInt(0))
+	if err != nil {
+		log.Printf("failed to get genesis block: %v", err)
+		gen = nil
+	}
+	if gen != nil {
+		id.GenesisHash = gen.Hash()
+	}
+	return &id, nil
+}
+
 func (rpc *RPCClient) DeployContract(ctx context.Context, privateKeyHex string, contractData string) (*types.Transaction, error) {
 	if len(privateKeyHex) > 2 && privateKeyHex[:2] == "0x" {
 		privateKeyHex = privateKeyHex[2:]

--- a/main.go
+++ b/main.go
@@ -159,6 +159,14 @@ func main() {
 				GetSnapshot(ctx, rpcUrl)
 			},
 		},
+		{
+			Name:    "id",
+			Aliases: []string{"id"},
+			Usage:   "Show chain id information",
+			Action: func(c *cli.Context) {
+				GetID(ctx, rpcUrl)
+			},
+		},
 	}
 	app.Run(os.Args)
 }
@@ -402,6 +410,25 @@ func GetSnapshot(ctx context.Context, rpcUrl string) {
 			fmt.Println("", addr.String(), str, tally.Votes)
 		}
 	}
+}
+
+func GetID(ctx context.Context, rpcUrl string) {
+	client := GetClient(rpcUrl)
+	id, err := client.GetID(ctx)
+	if err != nil {
+		log.Fatalf("Cannot get id info from the network: %v", err)
+	}
+	if verbose {
+		log.Println("Snapshot details:")
+	}
+	switch format {
+	case "json":
+		fmt.Println(marshalJSON(id))
+		return
+	}
+	fmt.Println("Network ID:", id.NetworkID)
+	fmt.Println("Chain ID:", id.ChainID)
+	fmt.Println("Genesis Hash:", id.GenesisHash.String())
 }
 
 func BuildSol(ctx context.Context, filename string) {


### PR DESCRIPTION
This PR adds an `id` command to show network id, chain id, and genesis hash.
```sh
web3-cli id
Network ID: 60
Chain ID: 60
Genesis Hash: 0x5b44a92a842a888b8b7cc1ff7eaac9800edf88a6a5f3d38850deb63d46acd880

web3-cli -testnet id
Network ID: 31337
Chain ID: 31337
Genesis Hash: 0x84337e882fad5883e2ed6e587ab5bdf711b7107a39abe8e080784bb30c8f047e

web3-cli -network ethereum id
Network ID: 1
Chain ID: 1
Genesis Hash: 0x03e43b36e734240240ab517dad42cc964a79122a487b9744fc4c7ff61a4c5c28

web3-cli -network ropsten id
2019/01/18 10:45:45 Failed to get chain ID: Method not found
Network ID: 3
Chain ID: <nil>
Genesis Hash: 0xa8a134fa3b1e1028a7811807fdd689c1cc0886e85012b2833cad4f72f532e2c6
```