### PR TITLE
move package main under /cmd/web3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD go.sum $D
 RUN go mod download
 # now build
 ADD . $D
-RUN cd $D && go build -o web3-alpine && cp web3-alpine /tmp/
+RUN cd $D && go build -o web3-alpine ./cmd/web3 && cp web3-alpine /tmp/
 
 # final stage
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 build: 
-	go build -o web3
+	go build ./cmd/web3
 
 install:
-	go build -o ${GOPATH}/bin/web3
+	go install ./cmd/web3
 
 docker: 
 	docker build -t gochain/web3:latest .
@@ -11,8 +11,8 @@ push: docker
 	# todo: version these, or auto push this using CI
 	docker push gochain/web3:latest
 
-test: build
-	./test.sh
+test:
+	go test ./...
 
 release:
 	GOOS=linux go build -o web3_linux

--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
-# Web3 CLI Tool
+# Web3
 
-Simple command line tool for interacting with web3 enabled blockchains - GoChain, Ethereum, etc.
+Simple command line tool for interacting with web3 enabled blockchains - GoChain, Ethereum, etc. 
+This repository also exports the backing golang `package web3`.
 
 ## Local installation
+
+### I have the Go language installed
+
+```sh
+go install github.com/gochain-io/web3/cmd/web3
+```
+
+### I don't have the go language installed
+
+#### a) Download a prebuilt release binary
+
+Coming soon.
+
+#### a) Build from source
 
 Clone the repo:
 
 ```sh
 git clone https://github.com/gochain-io/web3
 ```
-
-You also should have Docker installed [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
 
 Build:
 
@@ -23,6 +36,8 @@ Run:
  ```sh
  ./web3 help
  ```
+ 
+ Note: Some commands require [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 
 ## List of available commands
 

--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -14,8 +14,9 @@ import (
 	"time"
 
 	"github.com/gochain-io/gochain/common"
-
 	"github.com/urfave/cli"
+
+	"github.com/gochain-io/web3"
 )
 
 // Flags
@@ -42,7 +43,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = "web3"
-	app.Version = "0.0.2"
+	app.Version = "0.0.3"
 	app.Usage = "web3 cli tool"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -187,7 +188,7 @@ func getRPCURL(network, rpcURL string, testnet bool) string {
 			}
 			network = "testnet"
 		}
-		rpcURL = networkURL(network)
+		rpcURL = web3.NetworkURL(network)
 		if rpcURL == "" {
 			log.Fatal("Unrecognized network:", network)
 		}
@@ -201,23 +202,6 @@ func getRPCURL(network, rpcURL string, testnet bool) string {
 	return rpcURL
 }
 
-func networkURL(network string) string {
-	switch network {
-	case "testnet":
-		return "https://testnet-rpc.gochain.io"
-	case "mainnet", "":
-		return "https://rpc.gochain.io"
-	case "localhost":
-		return "http://localhost:8545"
-	case "ethereum":
-		return "https://main-rpc.linkpool.io"
-	case "ropsten":
-		return "https://ropsten-rpc.linkpool.io"
-	default:
-		return ""
-	}
-}
-
 func parseBigInt(value string) (*big.Int, error) {
 	if value == "" {
 		return nil, nil
@@ -228,7 +212,7 @@ func parseBigInt(value string) (*big.Int, error) {
 }
 
 func GetBlockDetails(ctx context.Context, rpcURL, blockNumber string) {
-	client := GetClient(rpcURL)
+	client := web3.GetClient(rpcURL)
 	blockN, err := parseBigInt(blockNumber)
 	if err != nil {
 		log.Fatalf("block number must be integer %q: %v", blockNumber, err)
@@ -287,7 +271,7 @@ var (
 )
 
 func GetTransactionDetails(ctx context.Context, rpcURL, txhash string) {
-	client := GetClient(rpcURL)
+	client := web3.GetClient(rpcURL)
 	tx, isPending, err := client.GetTransactionByHash(ctx, txhash)
 	if err != nil {
 		log.Fatalf("Cannot get transaction details from the network: %v", err)
@@ -321,7 +305,7 @@ func GetTransactionDetails(ctx context.Context, rpcURL, txhash string) {
 }
 
 func GetAddressDetails(ctx context.Context, rpcURL, addrHash string) {
-	client := GetClient(rpcURL)
+	client := web3.GetClient(rpcURL)
 	bal, err := client.GetBalance(ctx, addrHash, nil)
 	if err != nil {
 		log.Fatalf("Cannot get address balance from the network: %v", err)
@@ -353,7 +337,7 @@ func GetAddressDetails(ctx context.Context, rpcURL, addrHash string) {
 }
 
 func GetSnapshot(ctx context.Context, rpcUrl string) {
-	client := GetClient(rpcUrl)
+	client := web3.GetClient(rpcUrl)
 	s, err := client.GetSnapshot(ctx)
 	if err != nil {
 		log.Fatalf("Cannot get snapshot from the network: %v", err)
@@ -413,7 +397,7 @@ func GetSnapshot(ctx context.Context, rpcUrl string) {
 }
 
 func GetID(ctx context.Context, rpcUrl string) {
-	client := GetClient(rpcUrl)
+	client := web3.GetClient(rpcUrl)
 	id, err := client.GetID(ctx)
 	if err != nil {
 		log.Fatalf("Cannot get id info from the network: %v", err)
@@ -440,7 +424,7 @@ func BuildSol(ctx context.Context, filename string) {
 	if verbose {
 		log.Println("Building Sol:", str)
 	}
-	compileData, err := CompileSolidityString(ctx, str)
+	compileData, err := web3.CompileSolidityString(ctx, str)
 	if err != nil {
 		log.Fatalf("Failed to compile %q: %v", filename, err)
 	}
@@ -483,7 +467,7 @@ func BuildSol(ctx context.Context, filename string) {
 }
 
 func DeploySol(ctx context.Context, rpcUrl, privateKey, contractName string) {
-	client := GetClient(rpcUrl)
+	client := web3.GetClient(rpcUrl)
 	if _, err := os.Stat(contractName); os.IsNotExist(err) {
 		log.Fatalf("Cannot find the bin file: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gochain-io/web3-cli
+module github.com/gochain-io/web3
 
 require (
 	git.apache.org/thrift.git v0.12.0 // indirect

--- a/gochain.go
+++ b/gochain.go
@@ -1,4 +1,4 @@
-package main
+package web3
 
 import (
 	"context"
@@ -17,6 +17,23 @@ import (
 	"github.com/gochain-io/gochain/crypto"
 	"github.com/gochain-io/gochain/goclient"
 )
+
+func NetworkURL(network string) string {
+	switch network {
+	case "testnet":
+		return "https://testnet-rpc.gochain.io"
+	case "mainnet", "":
+		return "https://rpc.gochain.io"
+	case "localhost":
+		return "http://localhost:8545"
+	case "ethereum":
+		return "https://main-rpc.linkpool.io"
+	case "ropsten":
+		return "https://ropsten-rpc.linkpool.io"
+	default:
+		return ""
+	}
+}
 
 type RPCClient struct {
 	url    string

--- a/gochain_test.go
+++ b/gochain_test.go
@@ -1,4 +1,4 @@
-package main
+package web3
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 
 func ExampleRPCClient_GetBlockByNumber() {
 	ctx := context.Background()
-	for _, network := range []string{"mainnet","testnet"} {
-		c := GetClient(networkURL(network))
+	for _, network := range []string{"mainnet", "testnet"} {
+		c := GetClient(NetworkURL(network))
 
 		bl, err := c.GetBlockByNumber(ctx, nil)
 		if err != nil {

--- a/solc.go
+++ b/solc.go
@@ -1,4 +1,4 @@
-package main
+package web3
 
 import (
 	"bytes"

--- a/web3.go
+++ b/web3.go
@@ -1,0 +1,21 @@
+package web3
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/gochain-io/gochain/consensus/clique"
+	"github.com/gochain-io/gochain/core/types"
+)
+
+//TODO return pure response types from rpc instead of types.*
+type Client interface {
+	GetBalance(ctx context.Context, address string, blockNumber *big.Int) (*big.Int, error)
+	GetCode(ctx context.Context, address string, blockNumber *big.Int) ([]byte, error)
+	GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	GetTransactionByHash(ctx context.Context, hash string) (*types.Transaction, bool, error)
+	GetSnapshot(ctx context.Context) (*clique.Snapshot, error)
+	GetID(ctx context.Context) (*ID, error)
+	DeployContract(ctx context.Context, privateKeyHex string, contractData string) (*types.Transaction, error)
+	WaitForReceipt(ctx context.Context, tx *types.Transaction) (*types.Receipt, error)
+}


### PR DESCRIPTION
This PR moves `package main` and `main.go` to `/cmd/web3`, preps for replacing `goclient.Client` with `rpc.Client`, and does some other minor tweaks.