### PR TITLE
add receipt command

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ type Client interface {
 	GetBalance(ctx context.Context, address string, blockNumber *big.Int) (*big.Int, error)
 	GetCode(ctx context.Context, address string, blockNumber *big.Int) ([]byte, error)
 	GetBlockByNumber(ctx context.Context, number *big.Int, includeTxs bool) (*Block, error)
-	GetTransactionByHash(ctx context.Context, hash string) (*Transaction, error)
+	GetTransactionByHash(ctx context.Context, hash common.Hash) (*Transaction, error)
 	GetSnapshot(ctx context.Context) (*Snapshot, error)
 	GetID(ctx context.Context) (*ID, error)
 	GetTransactionReceipt(ctx context.Context, hash common.Hash) (*Receipt, error)
@@ -74,9 +74,9 @@ func (c *client) GetBlockByNumber(ctx context.Context, number *big.Int, includeT
 	return c.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), includeTxs)
 }
 
-func (c *client) GetTransactionByHash(ctx context.Context, hash string) (*Transaction, error) {
+func (c *client) GetTransactionByHash(ctx context.Context, hash common.Hash) (*Transaction, error) {
 	var tx *Transaction
-	err := c.r.CallContext(ctx, &tx, "eth_getTransactionByHash", hash)
+	err := c.r.CallContext(ctx, &tx, "eth_getTransactionByHash", hash.String())
 	if err != nil {
 		return nil, err
 	} else if tx == nil {


### PR DESCRIPTION
This PR adds a `receipt` command.
```sh
> web3 -testnet rc 0x3624d7a760d414e593cfe8b0349871a26414daa8ea9a707f56f6927852ff4de3
TxHash: 0x3624d7a760d414e593cfe8b0349871a26414daa8ea9a707f56f6927852ff4de3
GasUsed: 22192
Cumulative Gas Used: 22192
Status: 0
Post State: 0x
Bloom: 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
Logs: []

```