### PR TITLE
print balance in base units instead of wei; change base units with network

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleRPCClient_GetBlockByNumber() {
-	for _, network := range []string{"mainnet", "testnet"} {
+	for _, network := range []string{mainnetURL, testnetURL} {
 		exampleRPCClient_GetBlockByNumber(network)
 	}
 	// Output:
@@ -23,10 +23,10 @@ func ExampleRPCClient_GetBlockByNumber() {
 	// Got initial alloc balance.
 }
 
-func exampleRPCClient_GetBlockByNumber(network string) {
-	c, err := NewClient(NetworkURL(network))
+func exampleRPCClient_GetBlockByNumber(url string) {
+	c, err := NewClient(url)
 	if err != nil {
-		fmt.Printf("Failed to connect to network %q: %v\n", network, err)
+		fmt.Printf("Failed to connect to network %q: %v\n", url, err)
 		return
 	}
 	defer c.Close()
@@ -76,7 +76,7 @@ func exampleRPCClient_GetBlockByNumber(network string) {
 	if !ok {
 		panic("failed to parse big.Int string")
 	}
-	bal, err := c.GetBalance(ctx, testAddr(network), big.NewInt(0))
+	bal, err := c.GetBalance(ctx, testAddr(url), big.NewInt(0))
 	if err != nil {
 		fmt.Printf("Failed to get balance: %v\n", err)
 	}
@@ -91,9 +91,9 @@ func exampleRPCClient_GetBlockByNumber(network string) {
 
 func testAddr(network string) string {
 	switch network {
-	case "mainnet":
+	case mainnetURL:
 		return "0xf75b6e2d2d69da07f2940e239e25229350f8103f"
-	case "testnet":
+	case testnetURL:
 		return "0x2fe70f1df222c85ad6dd24a3376eb5ac32136978"
 	default:
 		panic("unsupported network: " + network)

--- a/web3.go
+++ b/web3.go
@@ -20,22 +20,38 @@ import (
 
 var NotFoundErr = errors.New("not found")
 
-//TODO instead return a rich Network struct w/ netId/chainId/baseUnit
-func NetworkURL(network string) string {
-	switch network {
-	case "testnet":
-		return "https://testnet-rpc.gochain.io"
-	case "mainnet", "":
-		return "https://rpc.gochain.io"
-	case "localhost":
-		return "http://localhost:8545"
-	case "ethereum":
-		return "https://main-rpc.linkpool.io"
-	case "ropsten":
-		return "https://ropsten-rpc.linkpool.io"
-	default:
-		return ""
-	}
+const (
+	testnetURL = "https://testnet-rpc.gochain.io"
+	mainnetURL = "https://rpc.gochain.io"
+)
+
+var Networks = map[string]Network{
+	"testnet": {
+		URL:  testnetURL,
+		Unit: "GO",
+	},
+	"mainnet": {
+		URL:  mainnetURL,
+		Unit: "GO",
+	},
+	"localhost": {
+		URL:  "http://localhost:8545",
+		Unit: "GO",
+	},
+	"ethereum": {
+		URL:  "https://main-rpc.linkpool.io",
+		Unit: "ETH",
+	},
+	"ropsten": {
+		URL:  "https://ropsten-rpc.linkpool.io",
+		Unit: "ETH",
+	},
+}
+
+type Network struct {
+	URL  string
+	Unit string
+	//TODO net_id, chain_id
 }
 
 var (


### PR DESCRIPTION
This PR changes the output of the address command to use base units instead of wei, and changes the units based on the network (`GO`/`ETH`).
Old:
```sh
> web3 -n localhost addr 0x634639241b1a25F2c7eEe5222D8eB929d6D14f42
Balance: 1000000000000000000000
Code: 
```
New:
```sh
> web3 addr 0x76C8B15940C5b0775389d4e6aDB854182930A0ee
Balance: 93329.275369019905580000 GO
> web3 -n ethereum addr 0x76C8B15940C5b0775389d4e6aDB854182930A0ee
Balance: 0.000000000000000000 ETH
```