### PR TITLE
cmd/web3: fix testnet flag

### DIFF
--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -63,8 +63,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:        "network, n",
-			Usage:       "The name of the network. Options: gochain/testnet/ethereum/ropsten/localhost. Default: gochain.",
-			Value:       "gochain",
+			Usage:       `The name of the network. Options: gochain/testnet/ethereum/ropsten/localhost. (default: "gochain")`,
 			Destination: &netName,
 			EnvVar:      "WEB3_NETWORK",
 			Hidden:      false},
@@ -308,7 +307,7 @@ func getNetwork(name, rpcURL string, testnet bool) web3.Network {
 	} else {
 		if testnet {
 			if name != "" {
-				log.Fatalf("Cannot set both network %q and testnet", network)
+				log.Fatalf("Cannot set both network %q and testnet", name)
 			}
 			name = "testnet"
 		} else if name == "" {


### PR DESCRIPTION
This PR fixes the following error when trying to use the `-testnet` flag:
`Cannot set both network "gochain" and testnet`