### PR TITLE
support either tx hashes or full details; output tx input data in various formats

### DIFF
--- a/client.go
+++ b/client.go
@@ -209,7 +209,7 @@ func (c *client) getBlock(ctx context.Context, method string, hashOrNum string, 
 	if block.Sha3Uncles != types.EmptyUncleHash && len(block.Uncles) == 0 {
 		return nil, fmt.Errorf("server returned empty uncle list but block header indicates uncles")
 	}
-	if block.TxsRoot == types.EmptyRootHash && len(block.Txs) > 0 {
+	if block.TxsRoot == types.EmptyRootHash && block.TxCount() > 0 {
 		return nil, fmt.Errorf("server returned non-empty transaction list but block header indicates no transactions")
 	}
 	if block.TxsRoot != types.EmptyRootHash && len(block.TxsRoot) == 0 {

--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gochain-io/gochain/v3/accounts/abi"
 	"github.com/gochain-io/gochain/v3/common"
+	"github.com/gochain-io/gochain/v3/common/hexutil"
 	"github.com/urfave/cli"
 
 	"github.com/gochain-io/web3"
@@ -52,7 +53,7 @@ func main() {
 	}()
 
 	// Flags
-	var netName, rpcUrl, function, contractAddress, contractFile, privateKey string
+	var netName, rpcUrl, function, contractAddress, contractFile, privateKey, txFormat, txInputFormat string
 	var amount int
 	var testnet, waitForReceipt bool
 
@@ -99,16 +100,38 @@ func main() {
 			Name:    "block",
 			Usage:   "Block details for a block number (decimal integer) or hash (hexadecimal with 0x prefix). Omit for latest.",
 			Aliases: []string{"bl"},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "tx",
+					Usage:       "Transaction format: count/hash/detail",
+					Destination: &txFormat,
+					Value:       "count",
+				},
+				cli.StringFlag{
+					Name:        "input",
+					Usage:       "Transaction input data format: len/hex/utf8",
+					Destination: &txInputFormat,
+					Value:       "len",
+				},
+			},
 			Action: func(c *cli.Context) {
-				GetBlockDetails(ctx, network.URL, c.Args().First())
+				GetBlockDetails(ctx, network, c.Args().First(), txFormat, txInputFormat)
 			},
 		},
 		{
 			Name:    "transaction",
 			Aliases: []string{"tx"},
 			Usage:   "Transaction details for a tx hash",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "input",
+					Usage:       "Transaction input data format: len/hex/utf8",
+					Destination: &txInputFormat,
+					Value:       "len",
+				},
+			},
 			Action: func(c *cli.Context) {
-				GetTransactionDetails(ctx, network, c.Args().First())
+				GetTransactionDetails(ctx, network, c.Args().First(), txInputFormat)
 			},
 		},
 		{
@@ -351,16 +374,24 @@ func parseBigInt(value string) (*big.Int, error) {
 	return i, nil
 }
 
-func GetBlockDetails(ctx context.Context, rpcURL, numberOrHash string) {
-	client, err := web3.NewClient(rpcURL)
+func GetBlockDetails(ctx context.Context, network web3.Network, numberOrHash string, txFormat, txInputFormat string) {
+	client, err := web3.NewClient(network.URL)
 	if err != nil {
-		log.Fatalf("Failed to connect to %q: %v", rpcURL, err)
+		log.Fatalf("Failed to connect to %q: %v", network.URL, err)
 	}
 	defer client.Close()
 	var block *web3.Block
+	var includeTxs bool
+	switch txFormat {
+	case "detail":
+		includeTxs = true
+	case "count", "hash":
+	default:
+		log.Fatalf(`Unrecognized transaction format %q: must be "count", "hash", or "detail"`, txFormat)
+	}
 	if strings.HasPrefix(numberOrHash, "0x") {
 		var err error
-		block, err = client.GetBlockByHash(ctx, numberOrHash, false)
+		block, err = client.GetBlockByHash(ctx, numberOrHash, includeTxs)
 		if err != nil {
 			log.Fatalf("Cannot get block details from the network: %v", err)
 		}
@@ -369,7 +400,7 @@ func GetBlockDetails(ctx context.Context, rpcURL, numberOrHash string) {
 		if err != nil {
 			log.Fatalf("Block argument must be a number (decimal integer) or hash (hexadecimal with 0x prefix) %q: %v", numberOrHash, err)
 		}
-		block, err = client.GetBlockByNumber(ctx, blockN, false)
+		block, err = client.GetBlockByNumber(ctx, blockN, includeTxs)
 		if err != nil {
 			log.Fatalf("Cannot get block details from the network: %v", err)
 		}
@@ -385,7 +416,7 @@ func GetBlockDetails(ctx context.Context, rpcURL, numberOrHash string) {
 
 	fmt.Println("Number:", block.Number)
 	fmt.Println("Time:", block.Timestamp.Format(time.RFC3339))
-	fmt.Println("Transactions:", len(block.Txs))
+	fmt.Println("Transactions:", block.TxCount())
 	gasPct := big.NewRat(int64(block.GasUsed), int64(block.GasLimit))
 	gasPct = gasPct.Mul(gasPct, big.NewRat(100, 1))
 	fmt.Printf("Gas Used: %d/%d (%s%%)\n", block.GasUsed, block.GasLimit, gasPct.FloatString(2))
@@ -411,6 +442,30 @@ func GetBlockDetails(ctx context.Context, rpcURL, numberOrHash string) {
 	if len(block.Signer) > 0 {
 		fmt.Println("Signer:", "0x"+common.Bytes2Hex(block.Signer))
 	}
+	if block.TxCount() > 0 {
+		switch txFormat {
+		case "hash":
+			fmt.Println("Transaction Hashes:")
+			for i, hash := range block.TxHashes {
+				fmt.Printf("\t%d\t%s\n", i, hash.Hex())
+			}
+		case "detail":
+			fmt.Println("Transaction Details:")
+			for i, tx := range block.TxDetails {
+				fmt.Printf("\t%d\t", i)
+				fmt.Print("Hash: ", tx.Hash.Hex())
+				fmt.Print(" From: ", tx.From.Hex())
+				fmt.Print(" To: ", tx.To.Hex())
+				fmt.Print(" Value: ", web3.WeiAsBase(tx.Value), " ", network.Unit)
+				fmt.Print(" Nonce: ", tx.Nonce)
+				fmt.Print(" Gas Limit: ", tx.GasLimit)
+				fmt.Print(" Gas Price: ", web3.WeiAsGwei(tx.GasPrice), " gwei")
+				fmt.Print(" ")
+				printInputData(tx.Input, txInputFormat)
+				fmt.Println()
+			}
+		}
+	}
 }
 
 type fmtAddresses []common.Address
@@ -428,7 +483,7 @@ func (fa fmtAddresses) String() string {
 	return b.String()
 }
 
-func GetTransactionDetails(ctx context.Context, network web3.Network, txhash string) {
+func GetTransactionDetails(ctx context.Context, network web3.Network, txhash, inputFormat string) {
 	client, err := web3.NewClient(network.URL)
 	if err != nil {
 		log.Fatalf("Failed to connect to %q: %v", network.URL, err)
@@ -460,6 +515,21 @@ func GetTransactionDetails(ctx context.Context, network web3.Network, txhash str
 	} else {
 		fmt.Println("Block Number:", tx.BlockNumber)
 		fmt.Println("Block Hash:", tx.BlockHash.String())
+	}
+	printInputData(tx.Input, inputFormat)
+	fmt.Println()
+}
+
+func printInputData(data []byte, format string) {
+	switch format {
+	case "len":
+		fmt.Print("Input Length: ", len(data), " bytes")
+	case "hex":
+		fmt.Print("Input: ", hexutil.Encode(data))
+	case "utf8":
+		fmt.Print("Input: ", string(data))
+	default:
+		log.Fatalf(`unrecognized input data format %q: expected "len", "hex", or "utf8"`, format)
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -94,8 +94,10 @@ type Block struct {
 	Nonce           types.BlockNonce
 	Hash            common.Hash
 
-	// TODO support full Transactions
-	Txs    []common.Hash
+	// Only one of TxHashes or TxDetails will be populated.
+	TxHashes  []common.Hash
+	TxDetails []*Transaction
+
 	Uncles []common.Hash
 }
 
@@ -110,7 +112,9 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 
 func (b *Block) MarshalJSON() ([]byte, error) {
 	var r rpcBlock
-	r.copyFrom(b)
+	if err := r.copyFrom(b); err != nil {
+		return nil, err
+	}
 	return json.Marshal(&r)
 }
 
@@ -120,6 +124,13 @@ func (b *Block) ExtraVanity() string {
 		l = 32
 	}
 	return string(b.ExtraData[:l])
+}
+
+func (b *Block) TxCount() int {
+	if b.TxHashes != nil {
+		return len(b.TxHashes)
+	}
+	return len(b.TxDetails)
 }
 
 type Transaction struct {


### PR DESCRIPTION
This PR adds a `-tx` flag to the `block` command, and an `-input` flag to the `block` and `tx` commands. 
```sh
OPTIONS:
   --tx value     Transaction format: count/hash/detail (default: "count")
   --input value  Transaction input data format: len/hex/utf8 (default: "len")
```
Before this change, only transaction hashes were fetched with blocks, only the count was displayed in the human readable output, and input data was always left out. Now the user may choose whether to display block transactions as `count`, `hash`, or `detail` - the default is `count` (the pre-existing behavior). For `hash` and `detail`, each tx is printed on a line following its index in the block (`detail` works with `-format json` as well). Users may also choose whether to display tx input data as `len`, `hex`, or `utf8` - the default is `len`.

Definitely open to name and/or format suggestions. The hash output is nice and clean:
```sh
...
MixDigest: 0x0000000000000000000000000000000000000000000000000000000000000000
Signer: 0x1d6dd30512ca935f36273c39fcdaa196fbe3d303ddb2f37ecf780f8fde8b69c13bbbe23c84d42fad47e90ef1429e4753bc96555d7c84791b466660a6d17a001800
Transaction Hashes:
	0	0x1055efe6b8e4c6c085914ff5986f5cef8973d814b0a895c1ff4afbe309a66028
	1	0x5e69f2e0510a11d039a9b022ee166b6459589bb39cdc033e9f7909d432f29307
	2	0x1f843b26d4457efab7c4ae2afc52b6000d4f934995369fcf22411c7745e09542
	3	0xfed8884a3f5ae311a4734409fea2ae387a6d18e73012764096abf6b44d36a72e
...
```
But the detail output is sort of dense (worse when it wraps):
```sh
...
Signer: 0xbf071fedb259bef7901004f66a2b7823bbe4c618d0028409c8d350cb4b90c5d631f46e84ba75e2863a81c8ea78dcdde3bf712f8f0728de01b6adae7ebda0259f00
Transaction Details:
	0	Hash: 0x1528e6509469b0abaef9351379cadb86e7fbf277ee58ba48e5534934daae9bd9 From: 0xF320A60c650Ce54697B4D6a232B31358bb7Dd427 To: 0xa23f8A7cEDd53Ee90460baa7d4654Dc9457DB505 Value: 0.000000000000000017GO Nonce: 92181 Gas Limit: 201734 Gas Price: 3.581222517 gwei Input: 0x
	1	Hash: 0xb6255abd8c96d69ec96dae7ed696887f2c92627cfc558145b04ddea50adb1704 From: 0xdfc947AB6E5aed846c8b71C9EE327fc30f6008d6 To: 0xE0D92301d90B9D1BBED7FEe2660Ca57536cE1c52 Value: 0.000000000000000010GO Nonce: 9092 Gas Limit: 308845 Gas Price: 3.350911431 gwei Input: 0x
	2	Hash: 0x16fa5b613146531a85003ab02ef417d6396692593ed76346e340e376bd031f96 From: 0xdfc947AB6E5aed846c8b71C9EE327fc30f6008d6 To: 0x18b7f4fE91dd484B53392236b3376696eF057Af0 Value: 0.000000000000000019GO Nonce: 9093 Gas Limit: 203146 Gas Price: 3.873731163 gwei Input: 0x
	3	Hash: 0x88aac9b2239a20f0c9ccab2c756c423a32cb692a241cf684b9193364fda729ae From: 0xdfc947AB6E5aed846c8b71C9EE327fc30f6008d6 To: 0xF6522549115D74453B8C751238E56B34c62af54f Value: 0.000000000000000014GO Nonce: 9094 Gas Limit: 293005 Gas Price: 3.567985475 gwei Input: 0x
...
```