### PR TITLE
remove fixed timeout from WaitForReceipt

### DIFF
--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -922,6 +922,7 @@ func DeploySol(ctx context.Context, rpcURL, privateKey, contractName string) {
 	if err != nil {
 		fatalExit(fmt.Errorf("Cannot deploy the contract: %v", err))
 	}
+	ctx, _ = context.WithTimeout(ctx, 10*time.Second)
 	receipt, err := web3.WaitForReceipt(ctx, client, tx.Hash)
 	if err != nil {
 		fatalExit(fmt.Errorf("Cannot get the receipt: %v", err))
@@ -986,6 +987,7 @@ func CallContract(ctx context.Context, rpcURL, privateKey, contractAddress, cont
 		fmt.Println("Transaction address:", tx.Hash.Hex())
 		return
 	}
+	ctx, _ = context.WithTimeout(ctx, 10*time.Second)
 	receipt, err := web3.WaitForReceipt(ctx, client, tx.Hash)
 	if err != nil {
 		fatalExit(fmt.Errorf("Cannot get the receipt: %v", err))

--- a/web3.go
+++ b/web3.go
@@ -306,13 +306,13 @@ func convertParameters(method abi.Method, inputParams []interface{}) []interface
 
 // WaitForReceipt polls for a transaction receipt until it is available, or ctx is cancelled.
 func WaitForReceipt(ctx context.Context, client Client, hash common.Hash) (*Receipt, error) {
-	for i := 0; ; i++ {
+	for {
 		receipt, err := client.GetTransactionReceipt(ctx, hash)
 		if err == nil {
 			return receipt, nil
 		}
-		if i >= (5) {
-			return nil, fmt.Errorf("cannot get the receipt: %v", err)
+		if err != NotFoundErr {
+			return nil, err
 		}
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This PR modifies WaitForReceipt by removing the fixed timeout (leaving it up to the caller instead), and only retrying `NotFoundErr` while returning other real errors.