### PR TITLE
fix latest block

### DIFF
--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -644,9 +644,13 @@ func GetBlockDetails(ctx context.Context, network web3.Network, numberOrHash str
 			fatalExit(fmt.Errorf("Cannot get block details from the network: %v", err))
 		}
 	} else {
-		blockN, err := web3.ParseBigInt(numberOrHash)
-		if err != nil {
-			fatalExit(fmt.Errorf("Block argument must be a number (decimal integer) or hash (hexadecimal with 0x prefix) %q: %v", numberOrHash, err))
+		var blockN *big.Int
+		// Don't try to parse empty string, which means 'latest'.
+		if numberOrHash != "" {
+			blockN, err = web3.ParseBigInt(numberOrHash)
+			if err != nil {
+				fatalExit(fmt.Errorf("Block argument must be a number (decimal integer) or hash (hexadecimal with 0x prefix) %q: %v", numberOrHash, err))
+			}
 		}
 		block, err = client.GetBlockByNumber(ctx, blockN, includeTxs)
 		if err != nil {

--- a/web3.go
+++ b/web3.go
@@ -413,7 +413,7 @@ func ParseBigInt(value string) (*big.Int, error) {
 	}
 	i, ok := new(big.Int).SetString(value, 10)
 	if !ok {
-		return nil, errors.New("Failed to parse integer")
+		return nil, fmt.Errorf("Failed to parse integer %q", value)
 	}
 	return i, nil
 }


### PR DESCRIPTION
This PR restores the ability to call the block subcommand without an argument to get the latest block.