### PR TITLE
support creating a client from rpc.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,13 +47,18 @@ type Client interface {
 	Close()
 }
 
-// NewClient creates a new client, backed by url (supported schemes "http", "https", "ws" and "wss").
-func NewClient(url string) (Client, error) {
+// Dial returns a new client backed by dialing url (supported schemes "http", "https", "ws" and "wss").
+func Dial(url string) (Client, error) {
 	r, err := rpc.Dial(url)
 	if err != nil {
 		return nil, err
 	}
-	return &client{r: r}, nil
+	return NewClient(r), nil
+}
+
+// NewClient returns a new client backed by an existing rpc.Client.
+func NewClient(r *rpc.Client) Client {
+	return &client{r: r}
 }
 
 type client struct {

--- a/client_test.go
+++ b/client_test.go
@@ -24,7 +24,7 @@ func ExampleRPCClient_GetBlockByNumber() {
 }
 
 func exampleRPCClient_GetBlockByNumber(url string) {
-	c, err := NewClient(url)
+	c, err := Dial(url)
 	if err != nil {
 		fmt.Printf("Failed to connect to network %q: %v\n", url, err)
 		return

--- a/cmd/web3/main.go
+++ b/cmd/web3/main.go
@@ -629,7 +629,7 @@ func getNetwork(name, rpcURL string, testnet bool) web3.Network {
 }
 
 func GetBlockDetails(ctx context.Context, network web3.Network, numberOrHash string, txFormat, txInputFormat string) {
-	client, err := web3.NewClient(network.URL)
+	client, err := web3.Dial(network.URL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", network.URL, err))
 	}
@@ -742,7 +742,7 @@ func (fa fmtAddresses) String() string {
 }
 
 func GetTransactionDetails(ctx context.Context, network web3.Network, txhash, inputFormat string) {
-	client, err := web3.NewClient(network.URL)
+	client, err := web3.Dial(network.URL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", network.URL, err))
 	}
@@ -796,7 +796,7 @@ func printInputData(data []byte, format string) {
 
 func GetTransactionReceipt(ctx context.Context, rpcURL, txhash, contractFile string) {
 	var myabi *abi.ABI
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
 	}
@@ -826,7 +826,7 @@ func GetAddressDetails(ctx context.Context, network web3.Network, addrHash, priv
 		}
 		addrHash = acct.PublicKey()
 	}
-	client, err := web3.NewClient(network.URL)
+	client, err := web3.Dial(network.URL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", network.URL, err))
 	}
@@ -864,7 +864,7 @@ func GetAddressDetails(ctx context.Context, network web3.Network, addrHash, priv
 }
 
 func GetSnapshot(ctx context.Context, rpcURL string) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
 	}
@@ -928,7 +928,7 @@ func GetSnapshot(ctx context.Context, rpcURL string) {
 }
 
 func GetID(ctx context.Context, rpcURL string) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
 	}
@@ -1008,7 +1008,7 @@ func DeploySol(ctx context.Context, rpcURL, privateKey, contractName string, upg
 	if contractName == "" {
 		fatalExit(errors.New("Missing contract name arg."))
 	}
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
 	}
@@ -1082,7 +1082,7 @@ func ListContract(contractFile string) {
 }
 
 func CallContract(ctx context.Context, rpcURL, privateKey, contractAddress, contractFile, functionName string, amount int, waitForReceipt bool, parameters ...interface{}) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
 	}
@@ -1125,7 +1125,7 @@ func CallContract(ctx context.Context, rpcURL, privateKey, contractAddress, cont
 }
 
 func Send(ctx context.Context, rpcURL, privateKey, toAddress, amount string) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to connect to %q: %v", rpcURL, err))
 	}
@@ -1319,7 +1319,7 @@ func printReceiptDetails(r *web3.Receipt, myabi *abi.ABI) {
 }
 
 func UpgradeContract(ctx context.Context, rpcURL, privateKey, contractAddress, newTargetAddress string, amount int) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		log.Fatalf("Failed to connect to %q: %v", rpcURL, err)
 	}
@@ -1341,7 +1341,7 @@ func UpgradeContract(ctx context.Context, rpcURL, privateKey, contractAddress, n
 }
 
 func GetTargetContract(ctx context.Context, rpcURL, contractAddress string) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		log.Fatalf("Failed to connect to %q: %v", rpcURL, err)
 	}
@@ -1363,7 +1363,7 @@ func GetTargetContract(ctx context.Context, rpcURL, contractAddress string) {
 }
 
 func PauseContract(ctx context.Context, rpcURL, privateKey, contractAddress string, amount int) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		log.Fatalf("Failed to connect to %q: %v", rpcURL, err)
 	}
@@ -1385,7 +1385,7 @@ func PauseContract(ctx context.Context, rpcURL, privateKey, contractAddress stri
 }
 
 func ResumeContract(ctx context.Context, rpcURL, privateKey, contractAddress string, amount int) {
-	client, err := web3.NewClient(rpcURL)
+	client, err := web3.Dial(rpcURL)
 	if err != nil {
 		log.Fatalf("Failed to connect to %q: %v", rpcURL, err)
 	}

--- a/cmd/web3/version.go
+++ b/cmd/web3/version.go
@@ -1,3 +1,3 @@
 package main
 
-var Version = "0.0.46"
+var Version = "0.1.0"


### PR DESCRIPTION
This PR adds support for creating a `web3.Client` from an `rpc.Client` instead of dialing a new one.